### PR TITLE
Add Snorkel to visualization list

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Contributions from:
 * [StatusWolf](https://github.com/box/StatusWolf)
 * [Dashing](http://shopify.github.io/dashing/)
 * [Tessera](https://github.com/urbanairship/tessera)
+* [Snorkel](https://github.com/logv/snorkel)
 
 ###Packaging
 * [0Install](http://0install.net/) - (all platforms)


### PR DESCRIPTION
Snorkel almost goes in a separate category, as it's more for realtime analysis (ad-hoc queries to slice and display data in various ways) rather than dashboards, but it's a bit of a fuzzy distinction (like most of the monitoring categories, really)